### PR TITLE
use buster as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,34 +6,34 @@ ENV DOCKER_HUGO_NAME="hugo_extended_${DOCKER_HUGO_VERSION}_Linux-64bit"
 ENV DOCKER_HUGO_BASE_URL="https://github.com/gohugoio/hugo/releases/download"
 ENV DOCKER_HUGO_URL="${DOCKER_HUGO_BASE_URL}/v${DOCKER_HUGO_VERSION}/${DOCKER_HUGO_NAME}.tar.gz"
 ENV DOCKER_HUGO_CHECKSUM_URL="${DOCKER_HUGO_BASE_URL}/v${DOCKER_HUGO_VERSION}/hugo_${DOCKER_HUGO_VERSION}_checksums.txt"
-ARG INSTALL_NODE="false"
+ENV PATH="/assets:${PATH}"
+ENV PATH="/assets/sass_embedded:${PATH}"
+ENV DEBIAN_FRONTEND="noninteractive"
 
-WORKDIR /build
-SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
-RUN apk add --no-cache --virtual .build-deps wget && \
-    apk add --no-cache \
+WORKDIR /assets
+
+RUN apt-get update && \
+    curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
+    apt-get install -y --no-install-recommends \
+    nodejs \
     git \
     bash \
-    make \
-    ca-certificates \
-    libc6-compat \
-    libstdc++ && \
+    make && \
+    apt-get autoclean && \
+    apt-get clean && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/* && \
     wget --quiet "${DOCKER_HUGO_URL}" && \
     wget --quiet "${DOCKER_HUGO_CHECKSUM_URL}" && \
     grep "${DOCKER_HUGO_NAME}.tar.gz" "./hugo_${DOCKER_HUGO_VERSION}_checksums.txt" | sha256sum -c - && \
     tar -zxvf "${DOCKER_HUGO_NAME}.tar.gz" && \
-    mv ./hugo /usr/bin/hugo && \
+    rm "${DOCKER_HUGO_NAME}.tar.gz" && \
     hugo version && \
-    apk del .build-deps && \
-    if [ "${INSTALL_NODE}" = "true" ]; then \
-        echo "Installing Node.js and npm..." && \
-        apk add --no-cache nodejs npm && \
-        npm i -g npm && \
-        npm cache clean --force && \
-        echo "node version: $(node -v)" && \
-        echo "npm version: $(npm -v)"; \
-    fi && \
-    rm -rf /build
+    curl -LJO https://github.com/sass/dart-sass-embedded/releases/download/1.0.0-beta.5/sass_embedded-1.0.0-beta.5-linux-x64.tar.gz && \
+    tar -zxvf sass_embedded-1.0.0-beta.5-linux-x64.tar.gz && \
+    rm sass_embedded-1.0.0-beta.5-linux-x64.tar.gz && \
+    npm i -g npm && \
+    npm cache clean --force
 
 WORKDIR /src
-ENTRYPOINT [ "/usr/bin/hugo" ]
+ENTRYPOINT [ "/assets/hugo" ]


### PR DESCRIPTION
testing for https://github.com/peaceiris/hugo-theme-iris/pull/264

```
docker build . -t ghcr.io/peaceiris/hugo:dartsass-debian --build-arg BASE_IMAGE="golang:1.15-buster" --build-arg INSTALL_NODE="true" | tss
```