### PR TITLE
ci: Use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -75,10 +75,9 @@ jobs:
       - name: Login to Registries
         if: github.event_name != 'pull_request'
         env:
-          GH_PAT: ${{ secrets.GH_PAT }}
           DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
         run: |
-          echo "${GH_PAT}" | docker login ghcr.io -u peaceiris --password-stdin
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u peaceiris --password-stdin
           echo "${DOCKER_HUB_TOKEN}" | docker login -u peaceiris --password-stdin
 
       - name: Push to GitHub Packages

--- a/.github/workflows/update-image.yml
+++ b/.github/workflows/update-image.yml
@@ -60,10 +60,9 @@ jobs:
       - name: Login to Registries
         if: github.event_name != 'pull_request'
         env:
-          GH_PAT: ${{ secrets.GH_PAT }}
           DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
         run: |
-          echo "${GH_PAT}" | docker login ghcr.io -u peaceiris --password-stdin
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u peaceiris --password-stdin
           echo "${DOCKER_HUB_TOKEN}" | docker login -u peaceiris --password-stdin
 
       - name: Push to GitHub Packages


### PR DESCRIPTION
cf. [Packages: Container registry now supports GITHUB_TOKEN - GitHub Changelog](https://github.blog/changelog/2021-03-24-packages-container-registry-now-supports-github_token/)