### PR TITLE
Add arm platforms

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,15 +23,15 @@ env:
 
 jobs:
   hadolint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container:
-      image: "ghcr.io/hadolint/hadolint:v2.4.1-alpine"
+      image: "ghcr.io/hadolint/hadolint:v2.7.0-alpine"
     steps:
       - uses: actions/checkout@v2.4.0
       - run: hadolint ./Dockerfile
 
   push:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: hadolint
     strategy:
       matrix:
@@ -49,6 +49,15 @@ jobs:
       - uses: actions/checkout@v2.4.0
 
       - uses: docker/setup-qemu-action@v1
+      - run: docker version
+
+      - name: Login to Registries
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u peaceiris --password-stdin
+          echo "${DOCKER_HUB_TOKEN}" | docker login -u peaceiris --password-stdin
 
       - name: Dump GitHub context
         env:
@@ -80,20 +89,32 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx
 
-      - run: docker version
-
-      - name: Build ${{ matrix.baseimage }} base image
+      - name: Build ${{ matrix.baseimage }} base image on pull_request
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           docker buildx create --use --driver docker-container
           docker buildx build . \
             --tag "${PKG_TAG}" \
             --build-arg BASE_IMAGE="${{ matrix.baseimage }}" \
             --build-arg INSTALL_NODE="${{ matrix.node }}" \
-            --platform linux/amd64,linux/arm64,linux/arm/v7 \
             --cache-from 'type=local,src=/tmp/.buildx-cache' \
             --cache-to 'type=local,mode=max,dest=/tmp/.buildx-cache-new' \
             --output 'type=docker'
           docker tag "${PKG_TAG}" "${HUB_TAG}"
+
+      - name: Build ${{ matrix.baseimage }} base image
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          docker buildx create --use --driver docker-container
+          docker buildx build . \
+            --tag "${PKG_TAG}" \
+            --tag "${HUB_TAG}" \
+            --build-arg BASE_IMAGE="${{ matrix.baseimage }}" \
+            --build-arg INSTALL_NODE="${{ matrix.node }}" \
+            --platform linux/amd64,linux/arm64,linux/arm/v7 \
+            --cache-from 'type=local,src=/tmp/.buildx-cache' \
+            --cache-to 'type=local,mode=max,dest=/tmp/.buildx-cache-new' \
+            --push
 
       - name: Replace cache dir
         run: |
@@ -101,20 +122,6 @@ jobs:
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
       - run: docker images
+        if: ${{ github.event_name == 'pull_request' }}
       - run: docker run --rm ${PKG_TAG} version
-
-      - name: Login to Registries
-        if: github.event_name != 'pull_request'
-        env:
-          DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u peaceiris --password-stdin
-          echo "${DOCKER_HUB_TOKEN}" | docker login -u peaceiris --password-stdin
-
-      - name: Push to GitHub Packages
-        if: github.event_name != 'pull_request'
-        run: docker push "${PKG_TAG}"
-
-      - name: Push to Docker Hub
-        if: github.event_name != 'pull_request'
-        run: docker push "${HUB_TAG}"
+        if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -48,7 +48,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2.4.0
 
-      - uses: docker/setup-qemu-action@v1
       - run: docker version
 
       - name: Login to Registries
@@ -102,26 +101,87 @@ jobs:
             --output 'type=docker'
           docker tag "${PKG_TAG}" "${HUB_TAG}"
 
-      - name: Build ${{ matrix.baseimage }} base image
-        if: ${{ github.event_name != 'pull_request' }}
-        run: |
-          docker buildx create --use --driver docker-container
-          docker buildx build . \
-            --tag "${PKG_TAG}" \
-            --tag "${HUB_TAG}" \
-            --build-arg BASE_IMAGE="${{ matrix.baseimage }}" \
-            --build-arg INSTALL_NODE="${{ matrix.node }}" \
-            --platform linux/amd64,linux/arm64,linux/arm/v7 \
-            --cache-from 'type=local,src=/tmp/.buildx-cache' \
-            --cache-to 'type=local,mode=max,dest=/tmp/.buildx-cache-new' \
-            --push
-
       - name: Replace cache dir
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
       - run: docker images
-        if: ${{ github.event_name == 'pull_request' }}
       - run: docker run --rm ${PKG_TAG} version
+
+      - name: Push to GitHub Packages
+        if: github.event_name != 'pull_request'
+        run: docker push "${PKG_TAG}"
+
+      - name: Push to Docker Hub
+        if: github.event_name != 'pull_request'
+        run: docker push "${HUB_TAG}"
+
+  push-arm:
+    runs-on: ubuntu-20.04
+    needs: hadolint
+    strategy:
+      matrix:
+        arch:
+          - "ARM"
+          - "ARM64"
+        baseimage:
+          - "alpine:3.14"
+          - "golang:1.17-alpine3.14"
+    env:
+      DOCKER_CLI_EXPERIMENTAL: enabled
+      DOCKER_BUILDKIT: 1
+    steps:
+      - uses: actions/checkout@v2.4.0
+
+      - uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm,arm64
+      - name: Setup docker buildx
+        run: docker buildx create --use --driver docker-container
+
+      - name: Login to Registries
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u peaceiris --password-stdin
+          echo "${DOCKER_HUB_TOKEN}" | docker login -u peaceiris --password-stdin
+
+      - name: Set env
+        run: |
+          if [ "${{ github.event_name }}" = 'release' ]; then
+            export TAG_NAME="${{ github.event.release.tag_name }}"
+          else
+            export TAG_NAME="latest"
+          fi
+          if [ "${{ startsWith( matrix.baseimage, 'golang') }}" = "true" ]; then
+            if [ "${{ matrix.node }}" = "true" ]; then
+              export TAG_NAME="${TAG_NAME}-full"
+            else
+              export TAG_NAME="${TAG_NAME}-mod"
+            fi
+          fi
+          echo "PKG_TAG=${DOCKER_BASE_NAME}:${TAG_NAME}" >> ${GITHUB_ENV}
+          echo "HUB_TAG=${DOCKER_HUB_BASE_NAME}:${TAG_NAME}" >> ${GITHUB_ENV}
+
+      - name: Build ${{ matrix.baseimage }} base image on pull-request
         if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          docker buildx build . \
+            --tag "${PKG_TAG}" \
+            --tag "${HUB_TAG}" \
+            --build-arg HUGO_ARCH="${{ matrix.arch }}" \
+            --build-arg BASE_IMAGE="${{ matrix.baseimage }}" \
+            --platform linux/arm64,linux/arm/v7
+
+      - name: Build ${{ matrix.baseimage }} base image
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          docker buildx build . \
+            --tag "${PKG_TAG}" \
+            --tag "${HUB_TAG}" \
+            --build-arg HUGO_ARCH="${{ matrix.arch }}" \
+            --build-arg BASE_IMAGE="${{ matrix.baseimage }}" \
+            --platform linux/arm64,linux/arm/v7 \
+            --push

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -48,6 +48,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2.4.0
 
+      - uses: docker/setup-qemu-action@v1
+
       - name: Dump GitHub context
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
@@ -87,6 +89,7 @@ jobs:
             --tag "${PKG_TAG}" \
             --build-arg BASE_IMAGE="${{ matrix.baseimage }}" \
             --build-arg INSTALL_NODE="${{ matrix.node }}" \
+            --platform linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6 \
             --cache-from 'type=local,src=/tmp/.buildx-cache' \
             --cache-to 'type=local,mode=max,dest=/tmp/.buildx-cache-new' \
             --output 'type=docker'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -89,7 +89,7 @@ jobs:
             --tag "${PKG_TAG}" \
             --build-arg BASE_IMAGE="${{ matrix.baseimage }}" \
             --build-arg INSTALL_NODE="${{ matrix.node }}" \
-            --platform linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6 \
+            --platform linux/amd64,linux/arm64,linux/arm/v7 \
             --cache-from 'type=local,src=/tmp/.buildx-cache' \
             --cache-to 'type=local,mode=max,dest=/tmp/.buildx-cache-new' \
             --output 'type=docker'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 ARG BASE_IMAGE
 FROM $BASE_IMAGE
 
-ARG DOCKER_HUGO_VERSION="0.89.0"
-ENV DOCKER_HUGO_NAME="hugo_extended_${DOCKER_HUGO_VERSION}_Linux-64bit"
-ENV DOCKER_HUGO_BASE_URL="https://github.com/gohugoio/hugo/releases/download"
-ENV DOCKER_HUGO_URL="${DOCKER_HUGO_BASE_URL}/v${DOCKER_HUGO_VERSION}/${DOCKER_HUGO_NAME}.tar.gz"
-ENV DOCKER_HUGO_CHECKSUM_URL="${DOCKER_HUGO_BASE_URL}/v${DOCKER_HUGO_VERSION}/hugo_${DOCKER_HUGO_VERSION}_checksums.txt"
+ARG HUGO_VERSION="0.89.0"
+ARG HUGO_ARCH="64bit"
+ENV HUGO_NAME="hugo_extended_${HUGO_VERSION}_Linux-${HUGO_ARCH}"
+ENV HUGO_BASE_URL="https://github.com/gohugoio/hugo/releases/download"
+ENV HUGO_URL="${HUGO_BASE_URL}/v${HUGO_VERSION}/${HUGO_NAME}.tar.gz"
+ENV HUGO_CHECKSUM_URL="${HUGO_BASE_URL}/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_checksums.txt"
 ARG INSTALL_NODE="false"
 
 WORKDIR /build
@@ -18,10 +19,10 @@ RUN apk add --update-cache --no-cache --virtual .build-deps wget && \
     ca-certificates \
     libc6-compat \
     libstdc++ && \
-    wget --quiet "${DOCKER_HUGO_URL}" && \
-    wget --quiet "${DOCKER_HUGO_CHECKSUM_URL}" && \
-    grep "${DOCKER_HUGO_NAME}.tar.gz" "./hugo_${DOCKER_HUGO_VERSION}_checksums.txt" | sha256sum -c - && \
-    tar -zxvf "${DOCKER_HUGO_NAME}.tar.gz" && \
+    wget --quiet "${HUGO_URL}" && \
+    wget --quiet "${HUGO_CHECKSUM_URL}" && \
+    grep "${HUGO_NAME}.tar.gz" "./hugo_${HUGO_VERSION}_checksums.txt" | sha256sum -c - && \
+    tar -zxvf "${HUGO_NAME}.tar.gz" && \
     mv ./hugo /usr/bin/hugo && \
     hugo version && \
     apk del .build-deps && \


### PR DESCRIPTION
- Node v16 will support ARM. Current active v14 does not.
- Both of [alpine:3.14](https://hub.docker.com/_/alpine?tab=tags) and [golang:1.17-alpine3.14](https://hub.docker.com/_/golang?tab=tags) have `linux/arm/v7` and `linux/arm64/v8` docker images.